### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Change Log
 **v1.0**
 - first version
 
-####feedback?
+#### feedback?
 
 * twitter: [@busta117](http://www.twitter.com/busta117)
 * mail: <busta117@gmail.com>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
